### PR TITLE
v0.18.1 add optical embeddings after tests without

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ TODOs.md
 test_data/
 examples/03_cve_test.rs
 examples/cve-full-run.txt
+arrowspace-rs.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrowspace"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 description = "Spectral vector search with taumode (λτ) indexing"
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/src/energymaps.rs
+++ b/src/energymaps.rs
@@ -688,7 +688,14 @@ impl EnergyMapsBuilder for ArrowSpaceBuilder {
 
         let l0 = ArrowSpace::bootstrap_centroid_laplacian(
             &centroids, energy_params.neighbor_k.max(self.lambda_k), self.normalise, self.sparsity_check);
-        let sub_centroids = ArrowSpace::diffuse_and_split_subcentroids(&centroids, &l0, &energy_params);
+        
+        let mut sub_centroids = ArrowSpace::diffuse_and_split_subcentroids(&centroids, &l0, &energy_params);
+        
+        // Apply optical compression to sub_centroids if specified
+        if let Some(tokens) = energy_params.optical_tokens {
+            sub_centroids = ArrowSpace::optical_compress_centroids(&sub_centroids, tokens, energy_params.trim_quantile);
+        }
+        
         let (gl_energy, _, _) = self.build_energy_laplacian(&sub_centroids, &energy_params);
 
         aspace.compute_taumode(&gl_energy);


### PR DESCRIPTION
implement optical compression call after tests in `pyarrowspace`

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied 

### Current behaviour
`build_energy` does not use optical compression

### New expected behaviour
`build_energy` uses optical compression

### Change logs
`build_energy` uses optical compression



<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
