### PR TITLE
adapt linear combination for negative cosine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "approx 0.5.1",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrowspace"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2024"
 description = "Graph Wiring for embeddings using physical networks wiring. Provides graph analysis, vector search and a energy-distribution stats."
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]

--- a/src/core.rs
+++ b/src/core.rs
@@ -168,7 +168,8 @@ impl ArrowItem {
         let cosine_sim = self.cosine_similarity(&other.item);
         let lambda_sim = self.lambda_component_similarity(other);
 
-        let result = alpha * cosine_sim + (1.0 - alpha) * lambda_sim;
+        // let result = alpha * cosine_sim + (1.0 - alpha) * lambda_sim;
+        let result = alpha * cosine_sim + cosine_sim.signum() * (1.0 - alpha) * lambda_sim;
 
         trace!(
             "Lambda similarity: semantic={:.6}, lambda={:.6}, combined={:.6}",


### PR DESCRIPTION
add `signum` to adapt lambda similarity to cosine sign

Fixes #

### Checklist
- [x] My branch is up-to-date with development branch.
- [x] Everything works and tested on latest stable Rust.
- [x] Coverage and Linting have been applied 

### Current behaviour
linear combination is designed for similarity among vectors in the same semantic context

### New expected behaviour
linear combination considers cosine sign

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->
